### PR TITLE
Fix order access authorization

### DIFF
--- a/order-service/src/main/java/com/example/orderservice/controller/OrderController.java
+++ b/order-service/src/main/java/com/example/orderservice/controller/OrderController.java
@@ -5,7 +5,10 @@ import com.example.orderservice.model.OrderItem;
 import com.example.orderservice.service.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -22,11 +25,26 @@ public class OrderController {
     public OrderController(OrderService orderService) {
         this.orderService = orderService;
     }
+
+    private UUID getAuthenticatedUserId() {
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth instanceof UsernamePasswordAuthenticationToken token) {
+            Object details = token.getDetails();
+            if (details instanceof UUID id) {
+                return id;
+            }
+        }
+        return null;
+    }
     @PostMapping
     public ResponseEntity<?> createOrder(
             @RequestParam UUID userId,
             @RequestBody List<OrderItem> items)
     {
+        UUID authId = getAuthenticatedUserId();
+        if (authId == null || !authId.equals(userId)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         return orderService.createOrder(userId, items);
     }
     @GetMapping("/test")
@@ -36,20 +54,37 @@ public class OrderController {
 
     @GetMapping
     public ResponseEntity<List<Order>> getAllOrders(@RequestParam(value = "userId" , required = false) UUID userId) {
-        if(userId != null) {
+        UUID authId = getAuthenticatedUserId();
+        if (userId != null) {
+            if (!userId.equals(authId)) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+            }
             return ResponseEntity.ok(orderService.getOrdersByUserId(userId));
-        }else return ResponseEntity.ok(orderService.getAllOrders());
+        }
+        return ResponseEntity.ok(orderService.getOrdersByUserId(authId));
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<Order> getOrderById(@PathVariable UUID id) {
         Optional<Order> order = orderService.getOrderById(id);
-        return order.map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
+        if (order.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!order.get().getUserId().equals(getAuthenticatedUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        return ResponseEntity.ok(order.get());
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteOrder(@PathVariable UUID id) {
+        Optional<Order> order = orderService.getOrderById(id);
+        if (order.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        if (!order.get().getUserId().equals(getAuthenticatedUserId())) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         orderService.deleteOrder(id);
         return ResponseEntity.noContent().build();
     }

--- a/order-service/src/main/java/com/example/orderservice/security/JwtFilter.java
+++ b/order-service/src/main/java/com/example/orderservice/security/JwtFilter.java
@@ -13,6 +13,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -28,8 +29,10 @@ public class JwtFilter extends OncePerRequestFilter {
             String token = authHeader.substring(7);
             if (jwtUtil.validateToken(token)) {
                 String email = jwtUtil.extractEmail(token);
+                UUID userId = jwtUtil.extractUserId(token);
                 UsernamePasswordAuthenticationToken authToken =
                         new UsernamePasswordAuthenticationToken(email, null, List.of());
+                authToken.setDetails(userId);
                 SecurityContextHolder.getContext().setAuthentication(authToken);
             }
         }

--- a/order-service/src/main/java/com/example/orderservice/util/JwtUtil.java
+++ b/order-service/src/main/java/com/example/orderservice/util/JwtUtil.java
@@ -35,6 +35,14 @@ public class JwtUtil {
                 .getSubject();
     }
 
+    public UUID extractUserId(String token) {
+        Object claim = Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("userId");
+        return claim != null ? UUID.fromString(claim.toString()) : null;
+    }
+
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);

--- a/user-service/src/main/java/com/example/userservice/util/JwtUtil.java
+++ b/user-service/src/main/java/com/example/userservice/util/JwtUtil.java
@@ -30,6 +30,14 @@ public class JwtUtil {
                 .getSubject();
     }
 
+    public UUID extractUserId(String token) {
+        Object claim = Jwts.parserBuilder().setSigningKey(key).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("userId");
+        return claim != null ? UUID.fromString(claim.toString()) : null;
+    }
+
     public boolean validateToken(String token) {
         try {
             Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);


### PR DESCRIPTION
## Summary
- extract user id from JWT in both services
- attach the user id in the order-service JWT filter
- validate that order operations are performed by the authenticated user only

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684472c586688330ad7bf7bb93c70a2b